### PR TITLE
[fix]application.properties に spring.main.web-application-type の設定を追加

### DIFF
--- a/MyPortfolio/src/main/resources/application.properties
+++ b/MyPortfolio/src/main/resources/application.properties
@@ -6,3 +6,4 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+spring.main.web-application-type=servlet

--- a/MyPortfolio/src/test/java/com/example/myPortfolio/MyPortfolioApplicationTests.java
+++ b/MyPortfolio/src/test/java/com/example/myPortfolio/MyPortfolioApplicationTests.java
@@ -3,7 +3,7 @@ package com.example.myPortfolio;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class MyPortfolioApplicationTests {
 
 	@Test

--- a/MyPortfolio/src/test/resources/application.properties
+++ b/MyPortfolio/src/test/resources/application.properties
@@ -5,3 +5,4 @@ spring.datasource.username=sa
 spring.datasource.password=password
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.jpa.hibernate.ddl-auto=create-drop
+spring.main.web-application-type=servlet


### PR DESCRIPTION
**概要:**  
`HomeController` クラス内の `HttpSession` が注入されず、アプリケーションの起動に失敗する問題を修正しました。これは、`application.properties` において `spring.main.web-application-type` が未設定、もしくは `none` となっていたことが原因でした。これを `servlet` に設定し、Web コンテキストを生成できるように修正しました。

また、テスト環境においても同様の問題が発生していたため、テスト用設定ファイルとテストクラスの修正を行いました。

---

**変更内容:**
1. **本番環境の修正:**
   - `src/main/resources/application.properties` ファイルに以下の設定を追加:
     ```properties
     spring.main.web-application-type=servlet
     ```
   - `HomeController` で `HttpSession` が正常に注入されることを確認。

2. **テスト環境の修正:**
   1. `src/test/resources/application-test.properties` ファイルにおいて、以下の設定を確認し、必要に応じて `servlet` に変更:
      ```properties
      spring.main.web-application-type=servlet
      ```
   2. テストクラス (`MyPortfolioApplicationTests`) の `@SpringBootTest` アノテーションを以下のように修正し、Web コンテキストを有効化:
      ```java
      @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
      public class MyPortfolioApplicationTests {
      }
      ```

---

**修正理由:**
`HomeController` において `HttpSession` が必要であるため、`servlet` コンテキストを有効にする必要がありました。設定を行わない場合、`HttpSession` の Bean が見つからず、アプリケーションが起動時に失敗するため、正しい `spring.main.web-application-type` の設定が必要です。

また、テスト環境においても同様のエラーが発生しており、`application-test.properties` の修正および `SpringBootTest` の Web 環境設定を変更することで、テスト実行時に `HttpSession` が正しく注入されることを確認しました。

---

**動作確認:**
- 本番環境・テスト環境共に、`HttpSession` の注入エラーが解消されていることを確認しました。
- `HomeController` の画面表示と、関連する機能（ユーザー情報の保持など）に問題がないことを確認済み。
- テストケースがすべて成功することを確認しました。

---

**関連 Issue:**  
#17
#19 

---

**補足情報:**  
必要に応じて、テストクラスの他の設定にも `WebAppConfiguration` の追加を検討し、テスト実行時に Web コンテキストが正しく有効化されることを確認してください。